### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,9 @@ A nice way to allow for online-offline development, but also use cdn's for packa
 
 .. |Build Status| image:: https://travis-ci.org/gabegaster/django-offlinecdn.svg?branch=master
    :target: https://travis-ci.org/gabegaster/django-offlinecdn
-.. |Version| image:: https://pypip.in/v/django-offlinecdn/badge.png
+.. |Version| image:: https://img.shields.io/pypi/v/django-offlinecdn.svg
    :target: https://warehouse.python.org/project/django-offlinecdn/
-.. |Downloads| image:: https://pypip.in/d/django-offlinecdn/badge.png
+.. |Downloads| image:: https://img.shields.io/pypi/dm/django-offlinecdn.svg
    :target: https://warehouse.python.org/project/django-offlinecdn/
 .. |Test Coverage| image:: https://coveralls.io/repos/gabegaster/django-offlinecdn/badge.png
    :target: https://coveralls.io/r/gabegaster/django-offlinecdn


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-offlinecdn))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-offlinecdn`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.